### PR TITLE
Refactor BaseTestCase to utilize twisted.trial.unittest.TestCase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pickle_jar
 node_modules
 npm-debug.log
 *.pyc
+_trial_temp/


### PR DESCRIPTION
I spent a little bit of time googling how to unit test cyclone applications and I came across the following answer on stack overflow.

http://stackoverflow.com/questions/12807992/how-do-i-write-tests-for-cyclone-in-the-style-of-tornado/14977944#14977944

I use the answer to implement a new BaseTestCase that extends the twisted.trial.unittest.TestCase class and was able to get tests running (and failing) correctly.

To run tests with the trial runner you call `trial tests.py` from the command line or simply use ./tests.py.  The test script's hashbang has been updated to point to trial.

Trial will automatically create a temp directory to store the picklejar directory which will isolate each test from any data that may have been created previously.  Trial also has an output log which could come in handy.

I've implemented this as its own branch with a pull request so you can review as this is changing the entire testing framework.  Trials is an extension of the built in python unittests but the behavior is different enough that you may want to check it out before changing the whole project over.
